### PR TITLE
chore: removed warning of native-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,16 +172,6 @@
                   <goal>test</goal>
                 </goals>
                 <phase>test</phase>
-                <configuration>
-                  <dependencies>
-                    <dependency>
-                      <groupId>org.junit.platform</groupId>
-                      <artifactId>junit-platform-launcher</artifactId>
-                      <version>1.10.2</version>
-                      <scope>test</scope>
-                    </dependency>
-                  </dependencies>
-                </configuration>
               </execution>
             </executions>
             <configuration>


### PR DESCRIPTION
This PR removes the warning of native-maven-plugin as follows:

```
Warning:  Parameter 'dependencies' is unknown for plugin 'native-maven-plugin:0.10.1:test (native test)'
```
